### PR TITLE
Family implementation tests & small fixes

### DIFF
--- a/R/sgl_irwls.R
+++ b/R/sgl_irwls.R
@@ -484,7 +484,7 @@ spgl_wlsfit <- function(warm, wx, gamma, static) {
     nnz <- as.integer(utils::tail(wx@p, 1))
 
     wls_fit <- dotCall64::.C64(
-      "wsgl",
+      "spmat_wsgl",
       SIGNATURE = c("integer", "integer", "integer", "integer", "double",
                     "integer", "integer", "double", "integer", "integer",
                     "integer", "double", "double", "double",

--- a/R/sgl_irwls.R
+++ b/R/sgl_irwls.R
@@ -44,7 +44,7 @@
 sgl_irwls <- function(
     bn, bs, ix, iy, nobs, nvars, x, y, pf, pfl1, dfmax, pmax, nlam,
     flmin, ulam, eps, maxit, vnames, group, intr, asparse, standardize,
-    lower_bnd, upper_bnd, weights, offset = NULL, family = gaussian(),
+    lower_bnd, upper_bnd, weights = NULL, offset = NULL, family = gaussian(),
     trace_it = 0, warm = NULL) {
 
   validate_family(family)

--- a/R/sgl_irwls.R
+++ b/R/sgl_irwls.R
@@ -76,7 +76,7 @@ sgl_irwls <- function(
 
   # get null deviance and lambda max, work out lambda values
   # we ALWAYS fit the intercept inside wsgl, so start it at zero
-  init <- initilizer(x, y, weights, family, intr = FALSE,
+  init <- initializer(x, y, weights, family, intr = FALSE,
                      has_offset, offset, pfl1, ulam)
   # this is supposed to be an upper bound
   # work out lambda values, cur_lambda is lambda_max / 0.99 when appropriate.
@@ -585,7 +585,7 @@ spgl_wlsfit <- function(warm, wx, gamma, static) {
 }
 
 
-initilizer <- function(x, y, weights, family, intr, has_offset, offset, pfl1,
+initializer <- function(x, y, weights, family, intr, has_offset, offset, pfl1,
                        ulam) {
   nobs <- nrow(x)
   nvars <- ncol(x)

--- a/tests/testthat/test-irwls.R
+++ b/tests/testthat/test-irwls.R
@@ -56,35 +56,35 @@ test_that("initializer works", {
   pfl2 <- pfl2 / sum(pfl2)
   ulam <- 0.5
 
-  usr_lambda <- initilizer(x, y, weights, gaussian(), TRUE, FALSE, NULL,
+  usr_lambda <- initializer(x, y, weights, gaussian(), TRUE, FALSE, NULL,
                            pfl1, ulam)
   expect_false(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)
-  usr_lambda_offset <- initilizer(x, y, weights, gaussian(), TRUE, TRUE, offset,
+  usr_lambda_offset <- initializer(x, y, weights, gaussian(), TRUE, TRUE, offset,
                            pfl1, ulam)
   expect_false(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)
-  usr_lambda_offset_noint <- initilizer(x, y, weights, gaussian(), FALSE,
+  usr_lambda_offset_noint <- initializer(x, y, weights, gaussian(), FALSE,
                                         TRUE, offset, pfl1, ulam)
   expect_false(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)
 
 
-  usr_lambda <- initilizer(x, y, weights, gaussian(), TRUE, FALSE, NULL,
+  usr_lambda <- initializer(x, y, weights, gaussian(), TRUE, FALSE, NULL,
                            pfl1, 0)
   expect_true(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)
-  usr_lambda_offset <- initilizer(x, y, weights, gaussian(), TRUE, TRUE, offset,
+  usr_lambda_offset <- initializer(x, y, weights, gaussian(), TRUE, TRUE, offset,
                                   pfl1, 0)
   expect_true(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)
-  usr_lambda_offset_noint <- initilizer(x, y, weights, gaussian(), FALSE,
+  usr_lambda_offset_noint <- initializer(x, y, weights, gaussian(), FALSE,
                                         TRUE, offset, pfl1, 0)
   expect_true(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)
 
   # try sparse
-  usr_lambda <- initilizer(xsp, y, weights, binomial(), TRUE, FALSE, NULL,
+  usr_lambda <- initializer(xsp, y, weights, binomial(), TRUE, FALSE, NULL,
                            pfl1, 0)
   expect_true(usr_lambda$findlambda)
   expect_equal(usr_lambda$cur_lambda * 0.99, usr_lambda$lambda_max)

--- a/tests/testthat/test-irwls_comparisons.R
+++ b/tests/testthat/test-irwls_comparisons.R
@@ -1,0 +1,78 @@
+set.seed(1)
+nobs <- 100L
+beta_star <- c(5, 5, 5, -5, -5, -5, 1, 0, 1, 0, 0, 0, 0, 2, 0)
+nvars <- length(beta_star)
+
+group <- rep(1:5, each = 3)
+x <- matrix(rnorm(nobs * length(beta_star)), nobs)
+y <- x %*% beta_star + rnorm(nobs)
+
+pr <- 1 / (1 + exp(-x %*% beta_star))
+ybin <- rbinom(nobs, 1, pr)
+
+bn <- as.integer(max(group))
+bs <- as.integer(as.numeric(table(group)))
+iy <- cumsum(bs)
+ix <- c(0, iy[-bn]) + 1
+ix <- as.integer(ix)
+iy <- as.integer(iy)
+
+pf <- as.double(sqrt(bs))
+pfl1 <- rep(as.double(pf / sum(pf) * nvars), 3)
+dfmax <- as.integer(max(group)) + 1L
+pmax <- as.integer(min(dfmax * 1.2, as.integer(max(group))))
+
+nlambda <- 100L
+flambda <- ifelse(nobs < nvars, 0.01, 1e-04)
+flmin <- as.double(flambda)
+ulam <- double(1)
+eps <- as.double(1e-08)
+maxit <- as.integer(3e+08)
+
+vnames <- colnames(x)
+intercept <- as.integer(TRUE)
+asparse <- as.double(0.05)
+standardize <- TRUE
+lower_bnd <- as.double(rep(-9.9e30, bn))
+upper_bnd <- as.double(rep(9.9e30, bn))
+intr <- as.integer(intercept)
+
+test_that("sgl_irwls provides the same result as sparsegl, gaussian family", {
+    res1 <- sgl_irwls(
+        bn, bs, ix, iy, nobs, nvars, x, y, pf, pfl1, dfmax, pmax, nlambda,
+        flmin, ulam, eps, maxit, vnames, group, intr, asparse, standardize,
+        lower_bnd, upper_bnd,
+        family = gaussian()
+    )
+
+    res2 <- sparsegl(
+        x, y, group, "gaussian", nlambda, flambda, NULL, pf, pfl1, intercept,
+        asparse, standardize, lower_bnd, upper_bnd, eps, maxit
+    )
+
+    expect_equal(
+        as.numeric(res1$coefficients),
+        as.numeric(res2$coefficients),
+        tolerance = 1e-10
+    )
+})
+
+test_that("sgl_irwls provides the same result as sparsegl, binomial family", {
+    res1 <- sgl_irwls(
+        bn, bs, ix, iy, nobs, nvars, x, ybin, pf, pfl1, dfmax, pmax, nlambda,
+        flmin, ulam, eps, maxit, vnames, group, intr, asparse, standardize,
+        lower_bnd, upper_bnd,
+        family = binomial()
+    )
+
+    res2 <- sparsegl(
+        x, ybin, group, "binomial", nlambda, flambda, NULL, pf, pfl1, intercept,
+        asparse, standardize, lower_bnd, upper_bnd, eps, maxit
+    )
+
+    expect_equal(
+        as.numeric(res1$coefficients),
+        as.numeric(res2$coefficients),
+        tolerance = 1e-10
+    )
+})

--- a/tests/testthat/test-sgl_irwls.R
+++ b/tests/testthat/test-sgl_irwls.R
@@ -50,7 +50,7 @@ sx[sx < sqrt(.Machine$double.eps)] <- 1 # Don't divide by zero!]
 xs <- 1 / sx
 x <- x %*% Matrix::Diagonal(x = xs)
 
-init <- initilizer(x, y, weights, family, intr = FALSE,
+init <- initializer(x, y, weights, family, intr = FALSE,
                    has_offset, offset, pfl1, ulam)
 cur_lambda <- init$cur_lambda
 findlambda <- init$findlambda


### PR DESCRIPTION
This PR has some tests for the gaussian and binomial algos, making sure sparsegl and irls have the same resultant coeffs.

Also, some small changes:
- a typo
- a default value for weights in `sgl_irwls`
- calling the right fortran fn for sparse matrices

The PR is pointing to the arb-glms branch.